### PR TITLE
Add More Redaction Factory Methods

### DIFF
--- a/http4s/src/main/scala/io/isomarcte/errors4s/http4s/RedactionConfiguration.scala
+++ b/http4s/src/main/scala/io/isomarcte/errors4s/http4s/RedactionConfiguration.scala
@@ -3,6 +3,7 @@ package org.errors4s.http4s
 import cats.syntax.all._
 import org.errors4s.http4s.headers._
 import org.http4s._
+import org.http4s.util._
 import scala.annotation.nowarn
 
 /** This type describes how to redact a request/response interaction when
@@ -107,6 +108,91 @@ object RedactionConfiguration {
         value.copy(redactUriQueryParam = f)
     }
 
+  /** Do not redact headers with names appearing in the given sets and query
+    * parameter keys appearing in the given set. If the header or query
+    * parameter name is not in the given set, then fallback to the
+    * [[#default]].
+    *
+    * @note No query parameter keys will be redacted, just values.
+    *
+    * @note Unlike HTTP header values, URI query parameter keys technically
+    *       ''are'' case sensitive, but usually they are treated as though
+    *       they are case insensitive. If you want case sensitive redaction,
+    *       then do not use this method.
+    */
+  def allowListOrDefaultCI(
+    allowedRequestHeaderNames: Set[CaseInsensitiveString],
+    allowedResponseHeaderNames: Set[CaseInsensitiveString],
+    allowedQueryParameterKeys: Set[CaseInsensitiveString]
+  ): RedactionConfiguration =
+    default
+      .withRedactRequestHeader(RedactRequestHeader.allowListOrDefaultCI(allowedRequestHeaderNames))
+      .withRedactResponseHeader(RedactResponseHeader.allowListOrDefaultCI(allowedResponseHeaderNames))
+      .withRedactUriQueryParam(RedactUriQueryParam.allowListOrDefaultCI(allowedQueryParameterKeys))
+
+  /** Do not redact headers with names appearing in the given sets and query
+    * parameter keys appearing in the given set. If the header or query
+    * parameter name is not in the given set, then fallback to the
+    * [[#default]].
+    *
+    * @note No query parameter keys will be redacted, just values.
+    *
+    * @note Unlike HTTP header values, URI query parameter keys technically
+    *       ''are'' case sensitive, but usually they are treated as though
+    *       they are case insensitive. If you want case sensitive redaction,
+    *       then do not use this method.
+    */
+  def allowListOrDefault(
+    allowedRequestHeaderNames: Set[String],
+    allowedResponseHeaderNames: Set[String],
+    allowedQueryParameterKeys: Set[String]
+  ): RedactionConfiguration =
+    allowListOrDefaultCI(
+      allowedRequestHeaderNames.map(CaseInsensitiveString.apply),
+      allowedResponseHeaderNames.map(CaseInsensitiveString.apply),
+      allowedQueryParameterKeys.map(CaseInsensitiveString.apply)
+    )
+
+  /** Do not redact headers with names appearing in the given sets and query
+    * parameter keys appearing in the given set. If the header or query
+    * parameter name is not in the given set, then fallback to the
+    * [[#default]].
+    *
+    * @note The same set of header names is used for both request and response
+    *       headers.
+    *
+    * @note No query parameter keys will be redacted, just values.
+    *
+    * @note Unlike HTTP header values, URI query parameter keys technically
+    *       ''are'' case sensitive, but usually they are treated as though
+    *       they are case insensitive. If you want case sensitive redaction,
+    *       then do not use this method.
+    */
+  def allowListOrDefaultCI(
+    allowedHeaderNames: Set[CaseInsensitiveString],
+    allowedQueryParameterKeys: Set[CaseInsensitiveString]
+  ): RedactionConfiguration = allowListOrDefaultCI(allowedHeaderNames, allowedHeaderNames, allowedQueryParameterKeys)
+
+  /** Do not redact headers with names appearing in the given sets and query
+    * parameter keys appearing in the given set. If the header or query
+    * parameter name is not in the given set, then fallback to the
+    * [[#default]].
+    *
+    * @note The same set of header names is used for both request and response
+    *       headers.
+    *
+    * @note No query parameter keys will be redacted, just values.
+    *
+    * @note Unlike HTTP header values, URI query parameter keys technically
+    *       ''are'' case sensitive, but usually they are treated as though
+    *       they are case insensitive. If you want case sensitive redaction,
+    *       then do not use this method.
+    */
+  def allowListOrDefault(
+    allowedHeaderNames: Set[String],
+    allowedQueryParameterKeys: Set[String]
+  ): RedactionConfiguration = allowListOrDefault(allowedHeaderNames, allowedHeaderNames, allowedQueryParameterKeys)
+
   // Newtype related private functions and values //
 
   private[this] def headerInAllowedHeaders(value: Header): Boolean =
@@ -139,6 +225,55 @@ object RedactionConfiguration {
       * the uri query parameter values redacted.
       */
     val unredacted: RedactRequestHeader = RedactRequestHeader(identity)
+
+    /** Redact headers using the given partial function falling back to an
+      * alternative redaction method.
+      */
+    def orElse(pf: PartialFunction[Header, Header], fallback: RedactRequestHeader): RedactRequestHeader =
+      RedactRequestHeader(header => pf.applyOrElse(header, fallback.value(_)))
+
+    /** Redact headers using the given partial function falling back to the
+      * default redaction method.
+      */
+    def orElseDefault(pf: PartialFunction[Header, Header]): RedactRequestHeader = orElse(pf, default)
+
+    /** Do not redact headers with names appearing in the given set, but redact
+      * all other headers.
+      */
+    def allowListCI(headerNames: Set[CaseInsensitiveString]): RedactRequestHeader =
+      RedactRequestHeader(header =>
+        if (headerNames.contains(header.name)) {
+          header
+        } else {
+          Header.Raw(header.name, defaultRedactValue(header.value))
+        }
+      )
+
+    /** Do not redact headers with names appearing in the given set, but redact
+      * all other headers.
+      */
+    def allowList(headerNames: Set[String]): RedactRequestHeader =
+      allowListCI(headerNames.map(CaseInsensitiveString.apply))
+
+    /** Do not redact headers with names appearing in the given set. If the header
+      * name is not in the given set, then fallback to the [[#default]]
+      * redaction method.
+      */
+    def allowListOrDefaultCI(headerNames: Set[CaseInsensitiveString]): RedactRequestHeader =
+      RedactRequestHeader(header =>
+        if (headerNames.contains(header.name)) {
+          header
+        } else {
+          default.value(header)
+        }
+      )
+
+    /** Do not redact headers with names appearing in the given set. If the header
+      * name is not in the given set, then fallback to the [[#default]]
+      * redaction method.
+      */
+    def allowListOrDefault(headerNames: Set[String]): RedactRequestHeader =
+      allowListOrDefaultCI(headerNames.map(CaseInsensitiveString.apply))
   }
 
   /** A newtype for a function to redact response header values.
@@ -166,6 +301,55 @@ object RedactionConfiguration {
       * the uri query parameter values redacted.
       */
     val unredacted: RedactResponseHeader = RedactResponseHeader(identity)
+
+    /** Redact headers using the given partial function falling back to an
+      * alternative redaction method.
+      */
+    def orElse(pf: PartialFunction[Header, Header], fallback: RedactResponseHeader): RedactResponseHeader =
+      RedactResponseHeader(header => pf.applyOrElse(header, fallback.value(_)))
+
+    /** Redact headers using the given partial function falling back to the
+      * default redaction method.
+      */
+    def orElseDefault(pf: PartialFunction[Header, Header]): RedactResponseHeader = orElse(pf, default)
+
+    /** Do not redact headers with names appearing in the given set, but redact
+      * all other headers.
+      */
+    def allowListCI(headerNames: Set[CaseInsensitiveString]): RedactResponseHeader =
+      RedactResponseHeader(header =>
+        if (headerNames.contains(header.name)) {
+          header
+        } else {
+          Header.Raw(header.name, defaultRedactValue(header.value))
+        }
+      )
+
+    /** Do not redact headers with names appearing in the given set, but redact
+      * all other headers.
+      */
+    def allowList(headerNames: Set[String]): RedactResponseHeader =
+      allowListCI(headerNames.map(CaseInsensitiveString.apply))
+
+    /** Do not redact headers with names appearing in the given set. If the header
+      * name is not in the given set, then fallback to the [[#default]]
+      * redaction method.
+      */
+    def allowListOrDefaultCI(headerNames: Set[CaseInsensitiveString]): RedactResponseHeader =
+      RedactResponseHeader(header =>
+        if (headerNames.contains(header.name)) {
+          header
+        } else {
+          default.value(header)
+        }
+      )
+
+    /** Do not redact headers with names appearing in the given set. If the header
+      * name is not in the given set, then fallback to the [[#default]]
+      * redaction method.
+      */
+    def allowListOrDefault(headerNames: Set[String]): RedactResponseHeader =
+      allowListOrDefaultCI(headerNames.map(CaseInsensitiveString.apply))
   }
 
   /** A newtype for a function to redact uri query parameter keys and values.
@@ -191,6 +375,93 @@ object RedactionConfiguration {
       * the request values redacted.
       */
     val unredacted: RedactUriQueryParam = RedactUriQueryParam((key, value) => (key, value))
+
+    /** Redact query parameter using the given partial function falling back to an
+      * alternative redaction method.
+      */
+    def orElse(
+      pf: PartialFunction[(String, Option[String]), (String, Option[String])],
+      fallback: RedactUriQueryParam
+    ): RedactUriQueryParam =
+      RedactUriQueryParam((key, value) =>
+        pf.applyOrElse(key -> value, (kv: (String, Option[String])) => fallback.value(kv._1, kv._2))
+      )
+
+    /** Redact query parameter using the given partial function falling back to
+      * the default redaction method.
+      */
+    def orElseDefault(pf: PartialFunction[(String, Option[String]), (String, Option[String])]): RedactUriQueryParam =
+      orElse(pf, default)
+
+    /** Do not redact query parameter values with the case insensitive name
+      * appearing in the given set, but redact all other query parameter
+      * values.
+      *
+      * @note No query parameter keys will be redacted, just values.
+      *
+      * @note Unlike HTTP header values, URI query parameter keys technically
+      *       ''are'' case sensitive, but usually they are treated as though
+      *       they are case insensitive. If you want case sensitive redaction,
+      *       then do not use this method.
+      */
+    def allowListCI(queryParamKeys: Set[CaseInsensitiveString]): RedactUriQueryParam =
+      RedactUriQueryParam {
+        case (key, Some(value)) if queryParamKeys.contains(CaseInsensitiveString(key)) =>
+          key -> Some(value)
+        case (key, Some(value)) =>
+          key -> Some(defaultRedactValue(value))
+        case (key, _) =>
+          key -> None
+      }
+
+    /** Do not redact query parameter values with the case insensitive name
+      * appearing in the given set, but redact all other query parameter
+      * values.
+      *
+      * @note No query parameter keys will be redacted, just values.
+      *
+      * @note Unlike HTTP header values, URI query parameter keys technically
+      *       ''are'' case sensitive, but usually they are treated as though
+      *       they are case insensitive. If you want case sensitive redaction,
+      *       then do not use this method.
+      */
+    def allowList(queryParamKeys: Set[CaseInsensitiveString]): RedactUriQueryParam =
+      allowListCI(queryParamKeys.map(CaseInsensitiveString.apply))
+
+    /** Do not redact query parameter values with a case insensitive name
+      * appearing in the given set. If the query parameter key name is not in
+      * the given set, then fallback to the [[#default]] redaction method.
+      *
+      * @note No query parameter keys will be redacted, just values.
+      *
+      * @note Unlike HTTP header values, URI query parameter keys technically
+      *       ''are'' case sensitive, but usually they are treated as though
+      *       they are case insensitive. If you want case sensitive redaction,
+      *       then do not use this method.
+      */
+    def allowListOrDefaultCI(queryParamKeys: Set[CaseInsensitiveString]): RedactUriQueryParam =
+      RedactUriQueryParam {
+        case (key, Some(value)) if queryParamKeys.contains(CaseInsensitiveString(value)) =>
+          key -> Some(value)
+        case (key, Some(value)) =>
+          key -> Some(defaultRedactValue(value))
+        case (key, _) =>
+          key -> None
+      }
+
+    /** Do not redact query parameter values with a case insensitive name
+      * appearing in the given set. If the query parameter key name is not in
+      * the given set, then fallback to the [[#default]] redaction method.
+      *
+      * @note No query parameter keys will be redacted, just values.
+      *
+      * @note Unlike HTTP header values, URI query parameter keys technically
+      *       ''are'' case sensitive, but usually they are treated as though
+      *       they are case insensitive. If you want case sensitive redaction,
+      *       then do not use this method.
+      */
+    def allowListOrDefault(queryParamKeys: Set[String]): RedactUriQueryParam =
+      allowListOrDefaultCI(queryParamKeys.map(CaseInsensitiveString.apply))
   }
 
   // Redacted newtypes, these are the results of applying the Redact newtype functions
@@ -280,25 +551,55 @@ object RedactionConfiguration {
       override val unredacted: Headers
     ) extends RedactedResponseHeaders
 
+    /** Create a [[RedactedResponseHeaders]] value from unredacted headers and a
+      * [[RedactResponseHeader]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromHeaders(headers: Headers, redact: RedactResponseHeader): RedactedResponseHeaders =
       RedactedResponseHeadersImpl(
         value = headers.foldMap(header => Headers.of(redact.value(header))),
         unredacted = headers
       )
 
+    /** Create a [[RedactedResponseHeaders]] value from a `Response` value.
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromResponse[F[_]](response: Response[F], redact: RedactResponseHeader): RedactedResponseHeaders =
       fromHeaders(response.headers, redact)
 
+    /** Create a [[RedactedResponseHeaders]] value from unredacted request headers
+      * and a [[RedactionConfiguration]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromHeadersAndConfig(headers: Headers, config: RedactionConfiguration): RedactedResponseHeaders =
       fromHeaders(headers, config.redactResponseHeader)
 
+    /** Create a [[RedactedResponseHeaders]] value from a `Response` value
+      * and a [[RedactionConfiguration]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromResponseAndConfig[F[_]](response: Response[F], config: RedactionConfiguration): RedactedResponseHeaders =
       fromHeaders(response.headers, config.redactResponseHeader)
   }
 
+  /** Uri values which been redacted.
+    */
   sealed trait RedactedUri {
+
+    /** The redacted Uri.
+      */
     def value: Uri
 
+    /** The original, unredacted, Uri.
+      */
     def unredacted: Uri
 
     // final //
@@ -322,13 +623,37 @@ object RedactionConfiguration {
         )
     }
 
+    /** Create a [[RedactedUri]] value from an unredacted Uri and a
+      * [[RedactUriQueryParam]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromUri(uri: Uri, redact: RedactUriQueryParam): RedactedUri = RedactedUriImpl(uri, redact)
 
+    /** Create a [[RedactedUri]] value from `Request` and a
+      * [[RedactUriQueryParam]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromRequest[F[_]](request: Request[F], redact: RedactUriQueryParam): RedactedUri = fromUri(request.uri, redact)
 
+    /** Create a [[RedactedUri]] value from a Uri and a
+      * [[RedactionConfiguration]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromUriAndConfig(uri: Uri, config: RedactionConfiguration): RedactedUri =
       fromUri(uri, config.redactUriQueryParam)
 
+    /** Create a [[RedactedUri]] value from a `Request` and a
+      * [[RedactionConfiguration]].
+      *
+      * @note Normally this is done for you when generating a
+      *       [[org.errors4s.http4s.client.ClientResponseError]].
+      */
     def fromRequestAndConfig[F[_]](request: Request[F], config: RedactionConfiguration): RedactedUri =
       fromUri(request.uri, config.redactUriQueryParam)
   }
@@ -336,7 +661,11 @@ object RedactionConfiguration {
   // General utility functions, exposed so users have an easy time modifying
   // the default behavior.
 
+  /** The default function used to redact a value. It redacts all values with
+    * the string "<REDACTED>".
+    */
   def defaultRedactValue[A](value: A): String = redactWithConstantString[A]("<REDACTED>")(value)
 
+  /** Redact a value using a constant string. */
   def redactWithConstantString[A](constant: String)(@nowarn("cat=unused") value: A): String = constant
 }

--- a/http4s/src/main/scala/io/isomarcte/errors4s/http4s/client/ClientResponseError.scala
+++ b/http4s/src/main/scala/io/isomarcte/errors4s/http4s/client/ClientResponseError.scala
@@ -25,7 +25,7 @@ import org.http4s._
   * trade off of ease of use while still collecting lots of error
   * information. If you wish to merely treat the error body as text, you might
   * consider
-  * [[org.errors4s.http4s.client.ClientResponseErrorTextBody#fromRequestResponseWithConfigSync]]
+  * [[org.errors4s.http4s.client.ClientResponseErrorTextBody#fromRequestResponseWithConfig]]
   * as well.
   *
   * @see [[https://http4s.org/v0.21/api/org/http4s/client/client Http4s Client]]

--- a/http4s/src/main/scala/io/isomarcte/errors4s/http4s/client/ClientResponseErrorTextBody.scala
+++ b/http4s/src/main/scala/io/isomarcte/errors4s/http4s/client/ClientResponseErrorTextBody.scala
@@ -25,7 +25,7 @@ object ClientResponseErrorTextBody {
   /** As [[#fromOptionRequestResponseWithConfigAndDecoder]], but uses the
     * default `EntityDecoder` for `String` values.
     */
-  def fromOptionRequestResponseWithConfigSync[F[_]: Sync](
+  def fromOptionRequestResponseWithConfig[F[_]: Sync](
     config: RedactionConfiguration
   )(request: Option[Request[F]])(response: Response[F]): F[ClientResponseErrorTextBody] =
     fromOptionRequestResponseWithConfigAndDecoder[F](config, EntityDecoder.text[F])(request)(response)
@@ -42,7 +42,7 @@ object ClientResponseErrorTextBody {
   /** As [[#fromRequestResponseWithConfigAndDecoder]], but uses the default
     * `EntityDecoder` for `String` values.
     */
-  def fromRequestResponseWithConfigSync[F[_]: Sync](
+  def fromRequestResponseWithConfig[F[_]: Sync](
     config: RedactionConfiguration
   )(request: Request[F])(response: Response[F]): F[ClientResponseErrorTextBody] =
     fromRequestResponseWithConfigAndDecoder[F](config, EntityDecoder.text[F])(request)(response)
@@ -58,7 +58,7 @@ object ClientResponseErrorTextBody {
   /** As [[#fromRequestResponseWithDecoder]], but uses the default
     * `EntityDecoder` for `String` values.
     */
-  def fromRequestResponseSync[F[_]: Sync](request: Request[F])(response: Response[F]): F[ClientResponseErrorTextBody] =
+  def fromRequestResponse[F[_]: Sync](request: Request[F])(response: Response[F]): F[ClientResponseErrorTextBody] =
     fromRequestResponseWithDecoder[F](EntityDecoder.text[F])(request)(response)
 
   /** As [[#fromOptionRequestResponseWithConfigAndDecoder]], but assumes the
@@ -73,7 +73,7 @@ object ClientResponseErrorTextBody {
   /** As [[#fromResponseWithConfigAndDecoder]], but uses the default
     * `EntityDecoder` for `String` values.
     */
-  def fromResponseWithConfigSync[F[_]: Sync](config: RedactionConfiguration)(
+  def fromResponseWithConfig[F[_]: Sync](config: RedactionConfiguration)(
     response: Response[F]
   ): F[ClientResponseErrorTextBody] = fromResponseWithConfigAndDecoder[F](config, EntityDecoder.text[F])(response)
 


### PR DESCRIPTION
Primarily, these make it easy to build RedactionConfiguration values from allow lists.

Also, added some missing Scaladoc and renamed some poorly named methods.