### PR TITLE
Fix Allow List

### DIFF
--- a/http4s/src/main/scala/io/isomarcte/errors4s/http4s/RedactionConfiguration.scala
+++ b/http4s/src/main/scala/io/isomarcte/errors4s/http4s/RedactionConfiguration.scala
@@ -425,7 +425,7 @@ object RedactionConfiguration {
       *       they are case insensitive. If you want case sensitive redaction,
       *       then do not use this method.
       */
-    def allowList(queryParamKeys: Set[CaseInsensitiveString]): RedactUriQueryParam =
+    def allowList(queryParamKeys: Set[String]): RedactUriQueryParam =
       allowListCI(queryParamKeys.map(CaseInsensitiveString.apply))
 
     /** Do not redact query parameter values with a case insensitive name

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.0.1-SNAPSHOT"
+ThisBuild / version := "1.1.0.0-SNAPSHOT"


### PR DESCRIPTION
The type signature for one of the `allowList` methods should have been `Set[String]`, but it was `Set[CaseInsensitiveString]`.